### PR TITLE
Fix alienfile

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -16,7 +16,8 @@ share {
    # china mirror
    #start_url 'https://hub.fastgit.org/stedolan/jq/releases/';
    plugin Download => (
-      version => qr/^jq-([0-9\.]+)\.tar\.gz$/o,
+      filter => qr/jq-([0-9\.]+)\.tar\.gz/,
+      version => qr/[0-9\.]+/,
    );
    plugin Extract => 'tar.gz';
    plugin 'Build::CMake';

--- a/alienfile
+++ b/alienfile
@@ -12,7 +12,7 @@ plugin 'Probe::CommandLine' => (
 );
 
 share {
-   start_url 'https://github.com/stedolan/jq/releases/';
+   start_url 'https://github.com/stedolan/jq/tags/';
    # china mirror
    #start_url 'https://hub.fastgit.org/stedolan/jq/releases/';
    plugin Download => (


### PR DESCRIPTION
The `releases` page doesn't seem to contain the `.tar.gz` file names any more, so here's a branch which uses the `tags` page instead.

It also uses the new Plugin options that you suggested.

With these changes, I can seemingly get the v1.6 archive to download correctly, but there's still a compilation error that I don't know if it's related. Please have a look and see if you can trouble shoot the actual Alien packaging part of this, I have no idea how to proceed from here.
